### PR TITLE
Add local age calculator tool

### DIFF
--- a/age-calculator.html
+++ b/age-calculator.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Age Calculator</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen py-8">
+    <div class="max-w-2xl mx-auto px-4">
+        <div class="bg-white rounded-2xl shadow-xl p-8">
+            <h1 class="text-3xl font-bold text-gray-800 text-center mb-8">🎂 Age Calculator</h1>
+            
+            <!-- Birth Date Input -->
+            <div class="mb-6">
+                <label for="birthDate" class="block text-lg font-semibold text-gray-700 mb-3">
+                    Enter your birth date (DDMMYYYY):
+                </label>
+                <input 
+                    type="text" 
+                    id="birthDate" 
+                    placeholder="02011996"
+                    maxlength="8"
+                    class="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none text-lg font-mono tracking-wider"
+                    oninput="formatDateInput(this); calculateAge()"
+                >
+                <div class="text-sm text-gray-500 mt-1">Format: Day Month Year (e.g., 02011996 for 2nd January 1996)</div>
+            </div>
+
+            <!-- Age Today Section -->
+            <div class="bg-blue-50 rounded-xl p-6 mb-6">
+                <h2 class="text-xl font-semibold text-blue-800 mb-3">Your Age Today</h2>
+                <div id="ageToday" class="text-2xl font-bold text-blue-600">
+                    Please enter your birth date
+                </div>
+            </div>
+
+            <!-- Custom Date Section -->
+            <div class="bg-green-50 rounded-xl p-6">
+                <h2 class="text-xl font-semibold text-green-800 mb-3">Your Age on a Specific Date</h2>
+                <div class="mb-4">
+                    <label for="customDate" class="block text-md font-medium text-gray-700 mb-2">
+                        Enter a date (DDMMYYYY):
+                    </label>
+                    <input 
+                        type="text" 
+                        id="customDate" 
+                        placeholder="15062024"
+                        maxlength="8"
+                        class="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-green-500 focus:outline-none text-lg font-mono tracking-wider"
+                        oninput="formatDateInput(this); calculateAge()"
+                    >
+                    <div class="text-sm text-gray-500 mt-1">Format: Day Month Year (e.g., 15062024 for 15th June 2024)</div>
+                </div>
+                <div id="ageOnDate" class="text-2xl font-bold text-green-600">
+                    Select a date to see your age
+                </div>
+            </div>
+
+            <!-- Additional Info -->
+            <div id="additionalInfo" class="mt-6 p-4 bg-gray-50 rounded-lg hidden">
+                <h3 class="text-lg font-semibold text-gray-700 mb-2">Fun Facts:</h3>
+                <div id="funFacts" class="text-gray-600 space-y-1"></div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        function formatDateInput(input) {
+            // Only allow numbers
+            input.value = input.value.replace(/[^0-9]/g, '');
+        }
+
+        function parseCustomDate(dateString) {
+            if (dateString.length !== 8) return null;
+            
+            const day = parseInt(dateString.substring(0, 2));
+            const month = parseInt(dateString.substring(2, 4));
+            const year = parseInt(dateString.substring(4, 8));
+            
+            // Basic validation
+            if (day < 1 || day > 31 || month < 1 || month > 12 || year < 1900 || year > 2100) {
+                return null;
+            }
+            
+            // Create date (month is 0-indexed in JavaScript)
+            const date = new Date(year, month - 1, day);
+            
+            // Check if the date is valid (handles invalid dates like 31st February)
+            if (date.getDate() !== day || date.getMonth() !== month - 1 || date.getFullYear() !== year) {
+                return null;
+            }
+            
+            return date;
+        }
+
+        function calculateAge() {
+            const birthDateInput = document.getElementById('birthDate');
+            const customDateInput = document.getElementById('customDate');
+            const ageTodayDiv = document.getElementById('ageToday');
+            const ageOnDateDiv = document.getElementById('ageOnDate');
+            const additionalInfoDiv = document.getElementById('additionalInfo');
+            const funFactsDiv = document.getElementById('funFacts');
+
+            if (!birthDateInput.value || birthDateInput.value.length !== 8) {
+                ageTodayDiv.innerHTML = 'Please enter your birth date (8 digits)';
+                ageOnDateDiv.innerHTML = 'Enter a date to see your age';
+                additionalInfoDiv.classList.add('hidden');
+                return;
+            }
+
+            const birthDate = parseCustomDate(birthDateInput.value);
+            if (!birthDate) {
+                ageTodayDiv.innerHTML = '<span class="text-red-500">Invalid birth date format!</span>';
+                ageOnDateDiv.innerHTML = 'Enter a date to see your age';
+                additionalInfoDiv.classList.add('hidden');
+                return;
+            }
+
+            const today = new Date();
+
+            // Calculate age today
+            const ageToday = calculateAgeDetails(birthDate, today);
+            ageTodayDiv.innerHTML = formatAge(ageToday);
+
+            // Calculate age on custom date if provided
+            if (customDateInput.value && customDateInput.value.length === 8) {
+                const customDate = parseCustomDate(customDateInput.value);
+                
+                if (!customDate) {
+                    ageOnDateDiv.innerHTML = '<span class="text-red-500">Invalid date format!</span>';
+                } else if (customDate < birthDate) {
+                    ageOnDateDiv.innerHTML = '<span class="text-red-500">Date is before birth date!</span>';
+                } else {
+                    const ageOnCustomDate = calculateAgeDetails(birthDate, customDate);
+                    ageOnDateDiv.innerHTML = formatAge(ageOnCustomDate);
+                }
+            } else {
+                ageOnDateDiv.innerHTML = 'Enter a date to see your age';
+            }
+
+            // Show fun facts
+            showFunFacts(birthDate, today, funFactsDiv);
+            additionalInfoDiv.classList.remove('hidden');
+        }
+
+        function calculateAgeDetails(birthDate, targetDate) {
+            let years = targetDate.getFullYear() - birthDate.getFullYear();
+            let months = targetDate.getMonth() - birthDate.getMonth();
+            let days = targetDate.getDate() - birthDate.getDate();
+
+            if (days < 0) {
+                months--;
+                const lastMonth = new Date(targetDate.getFullYear(), targetDate.getMonth(), 0);
+                days += lastMonth.getDate();
+            }
+
+            if (months < 0) {
+                years--;
+                months += 12;
+            }
+
+            const totalDays = Math.floor((targetDate - birthDate) / (1000 * 60 * 60 * 24));
+            const totalWeeks = Math.floor(totalDays / 7);
+            const totalMonths = years * 12 + months;
+
+            return { years, months, days, totalDays, totalWeeks, totalMonths };
+        }
+
+        function formatAge(age) {
+            let result = '';
+            
+            if (age.years > 0) {
+                result += `<span class="text-3xl">${age.years}</span> year${age.years !== 1 ? 's' : ''}`;
+            }
+            
+            if (age.months > 0) {
+                if (result) result += ', ';
+                result += `<span class="text-2xl">${age.months}</span> month${age.months !== 1 ? 's' : ''}`;
+            }
+            
+            if (age.days > 0) {
+                if (result) result += ', ';
+                result += `<span class="text-xl">${age.days}</span> day${age.days !== 1 ? 's' : ''}`;
+            }
+
+            if (!result) {
+                result = '<span class="text-2xl">Born today! 🎉</span>';
+            }
+
+            return result;
+        }
+
+        function showFunFacts(birthDate, today, container) {
+            const age = calculateAgeDetails(birthDate, today);
+            const nextBirthday = new Date(today.getFullYear(), birthDate.getMonth(), birthDate.getDate());
+            
+            if (nextBirthday < today) {
+                nextBirthday.setFullYear(today.getFullYear() + 1);
+            }
+            
+            const daysToNextBirthday = Math.ceil((nextBirthday - today) / (1000 * 60 * 60 * 24));
+            
+            container.innerHTML = `
+                <div>📅 You've lived for <strong>${age.totalDays.toLocaleString()}</strong> days</div>
+                <div>📆 That's <strong>${age.totalWeeks.toLocaleString()}</strong> weeks</div>
+                <div>🗓️ Or <strong>${age.totalMonths}</strong> months total</div>
+                <div>🎈 Days until next birthday: <strong>${daysToNextBirthday}</strong></div>
+                <div>⏰ You've experienced approximately <strong>${Math.floor(age.totalDays * 24).toLocaleString()}</strong> hours of life!</div>
+            `;
+        }
+
+        // No default date needed for text input
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     <div class="space"></div>
     <section class="card cardWhite">
       <div class="tools">
-        <a class="tool t-blue tool-emoji" data-emoji="🎂" href="https://shahssolutions.my.canva.site/age-calculation-tool" target="_blank" rel="noopener" aria-label="Open Age Tool">
+        <a class="tool t-blue tool-emoji" data-emoji="🎂" href="age-calculator.html" target="_blank" rel="noopener" aria-label="Open Age Tool">
           <div class="tTitle">Age Tool</div>
         </a>
         <a class="tool t-gold tool-emoji" data-emoji="🛡️" href="https://shahssolutions.my.canva.site/insurancecalculator" target="_blank" rel="noopener" aria-label="Open Is Your Insurance Enough">


### PR DESCRIPTION
## Summary
- add standalone `age-calculator.html` with Tailwind-based age computation interface
- update Age Tool card in `index.html` to open the new page instead of external link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a01ccbaea08332938c2a8dc9733757