### PR TITLE
Add local age calculator tool

### DIFF
--- a/age-calculator.html
+++ b/age-calculator.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Age Calculator</title>
+  <style>
+    body{margin:0;background:#000;color:#00eaff;font-family:Arial,sans-serif;overflow:hidden}
+    #particles{position:fixed;inset:0;z-index:-1}
+    .container{max-width:600px;margin:4rem auto;padding:2rem;background:rgba(255,255,255,.05);border:1px solid rgba(0,234,255,.3);border-radius:20px;backdrop-filter:blur(10px);box-shadow:0 0 20px rgba(0,234,255,.2)}
+    h1{text-align:center;margin-top:0}
+    label{display:block;margin-top:1rem;margin-bottom:.5rem}
+    input{width:100%;padding:.8rem;background:rgba(0,0,0,.4);border:1px solid #00eaff;border-radius:8px;color:#00eaff}
+    input:focus{outline:none;box-shadow:0 0 10px #00eaff}
+    .result{margin-top:1rem;font-size:1.2rem}
+  </style>
+</head>
+<body>
+  <canvas id="particles"></canvas>
+  <div class="container">
+    <h1>🎂 Age Calculator</h1>
+    <label for="birthDate">Enter your birth date (DDMMYYYY):</label>
+    <input type="text" id="birthDate" maxlength="8" placeholder="02011996" oninput="formatDateInput(this);calculateAge();">
+    <div id="ageToday" class="result">Please enter your birth date</div>
+    <hr style="border-color:rgba(0,234,255,.2);margin:2rem 0;">
+    <label for="customDate">Enter a date (DDMMYYYY):</label>
+    <input type="text" id="customDate" maxlength="8" placeholder="15062024" oninput="formatDateInput(this);calculateAge();">
+    <div id="ageOnDate" class="result">Select a date to see your age</div>
+    <div id="additionalInfo" style="display:none;margin-top:2rem;">
+      <h3>Fun Facts:</h3>
+      <div id="funFacts"></div>
+    </div>
+  </div>
+  <script>
+    const canvas=document.getElementById('particles'),ctx=canvas.getContext('2d');
+    function resize(){canvas.width=window.innerWidth;canvas.height=window.innerHeight}
+    window.addEventListener('resize',resize);resize();
+    const particles=[];for(let i=0;i<60;i++){particles.push({x:Math.random()*canvas.width,y:Math.random()*canvas.height,vx:(Math.random()-.5)*.5,vy:(Math.random()-.5)*.5,size:2+Math.random()*2})}
+    function draw(){ctx.clearRect(0,0,canvas.width,canvas.height);particles.forEach(p=>{p.x+=p.vx;p.y+=p.vy;if(p.x<0||p.x>canvas.width)p.vx*=-1;if(p.y<0||p.y>canvas.height)p.vy*=-1;ctx.beginPath();ctx.arc(p.x,p.y,p.size,0,Math.PI*2);ctx.fillStyle='rgba(0,234,255,.5)';ctx.fill()});requestAnimationFrame(draw)}
+    draw();
+    function formatDateInput(input){input.value=input.value.replace(/[^0-9]/g,'')}
+    function parseCustomDate(str){if(str.length!==8)return null;const d=parseInt(str.slice(0,2)),m=parseInt(str.slice(2,4)),y=parseInt(str.slice(4,8));if(d<1||d>31||m<1||m>12||y<1900||y>2100)return null;const date=new Date(y,m-1,d);if(date.getDate()!==d||date.getMonth()!==m-1||date.getFullYear()!==y)return null;return date}
+    function calculateAge(){const birth=document.getElementById('birthDate'),custom=document.getElementById('customDate'),todayDiv=document.getElementById('ageToday'),onDateDiv=document.getElementById('ageOnDate'),info=document.getElementById('additionalInfo'),facts=document.getElementById('funFacts');if(!birth.value||birth.value.length!==8){todayDiv.textContent='Please enter your birth date (8 digits)';onDateDiv.textContent='Select a date to see your age';info.style.display='none';return}const birthDate=parseCustomDate(birth.value);if(!birthDate){todayDiv.innerHTML='<span style="color:#ff4d4d;">Invalid birth date format!</span>';onDateDiv.textContent='Select a date to see your age';info.style.display='none';return}const today=new Date();todayDiv.innerHTML=formatAge(calculateAgeDetails(birthDate,today));if(custom.value&&custom.value.length===8){const customDate=parseCustomDate(custom.value);if(!customDate){onDateDiv.innerHTML='<span style="color:#ff4d4d;">Invalid date format!</span>'}else if(customDate<birthDate){onDateDiv.innerHTML='<span style="color:#ff4d4d;">Date is before birth date!</span>'}else{onDateDiv.innerHTML=formatAge(calculateAgeDetails(birthDate,customDate))}}else{onDateDiv.textContent='Select a date to see your age'}showFunFacts(birthDate,today,facts);info.style.display='block'}
+    function calculateAgeDetails(b,t){let y=t.getFullYear()-b.getFullYear(),m=t.getMonth()-b.getMonth(),d=t.getDate()-b.getDate();if(d<0){m--;const lm=new Date(t.getFullYear(),t.getMonth(),0);d+=lm.getDate()}if(m<0){y--;m+=12}const totalDays=Math.floor((t-b)/(1000*60*60*24)),totalWeeks=Math.floor(totalDays/7),totalMonths=y*12+m;return{years:y,months:m,days:d,totalDays,totalWeeks,totalMonths}}
+    function formatAge(a){let r='';if(a.years>0){r+=`<span style="font-size:1.5rem;">${a.years}</span> year${a.years!==1?'s':''}`}if(a.months>0){if(r)r+=', ';r+=`<span style="font-size:1.2rem;">${a.months}</span> month${a.months!==1?'s':''}`}if(a.days>0){if(r)r+=', ';r+=`<span>${a.days}</span> day${a.days!==1?'s':''}`}if(!r)r='<span style="font-size:1.2rem;">Born today! 🎉</span>';return r}
+    function showFunFacts(b,t,c){const a=calculateAgeDetails(b,t);const nb=new Date(t.getFullYear(),b.getMonth(),b.getDate());if(nb<t)nb.setFullYear(t.getFullYear()+1);const daysTo=Math.ceil((nb-t)/(1000*60*60*24));c.innerHTML=`<div>📅 You've lived for <strong>${a.totalDays.toLocaleString()}</strong> days</div><div>📆 That's <strong>${a.totalWeeks.toLocaleString()}</strong> weeks</div><div>🗓️ Or <strong>${a.totalMonths}</strong> months total</div><div>🎈 Days until next birthday: <strong>${daysTo}</strong></div><div>⏰ You've experienced approximately <strong>${Math.floor(a.totalDays*24).toLocaleString()}</strong> hours of life!</div>`}
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,142 +1,44 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@1.39.1/tabler-icons.min.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>LIC Sales Toolkit</title>
   <style>
-    :root{--ink:#0b1220;--muted:#64748b;--card:#ffffff;--line:#e2e8f0;--licBlue:#1D4E9E;--licGold:#FBC707;--sky:#EEF4FF;--ivory:#FFF9E6;--goldBorder:#F4D065;--r:16px;--shadow:0 14px 36px rgba(2,6,23,.10)}
-    html,body{margin:0}
-    body{font-family:Inter,system-ui,Arial;background:linear-gradient(180deg,#BFD6FF 0%, #E4EEFF 60%, #F4F8FF 100%);background-attachment:fixed;color:var(--ink)}
-    .wrap{max-width:720px;margin:auto;padding:16px}
-    .card{background:var(--ivory);border:1px solid var(--goldBorder);border-radius:20px;box-shadow:var(--shadow);padding:16px;position:relative;overflow:hidden}
-    .cardWhite{background:#ffffff;border:1px solid #e7eefc}
-    .card::after{content:"";position:absolute;right:-40px;bottom:-40px;width:200px;height:200px;border-radius:50%;background:radial-gradient(closest-side, rgba(251,199,7,.12), rgba(251,199,7,0));pointer-events:none;z-index:0}
-    .row{display:flex;gap:12px;align-items:center}
-    .space{height:14px}
-    .avatar{width:56px;height:56px;border-radius:50%;background:#ffe8a3;display:grid;place-items:center;font-weight:700;position:relative;overflow:hidden;border:2px solid var(--goldBorder)}
-    .avatar::after{content:"";position:absolute;inset:-3px;border-radius:50%;border:3px solid var(--licBlue);opacity:.22;pointer-events:none}
-    .avatar img{width:100%;height:100%;object-fit:cover;display:none}
-    .avatar span{z-index:1}
-    .title h1{font-size:18px;line-height:1.2;margin:0;letter-spacing:.1px}
-    .contact{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
-    .chip{font-size:13px;border:1px solid var(--line);border-radius:999px;padding:8px 10px;color:#0b1220;background:#fff}
-    .chip a{color:inherit;text-decoration:none}
-    .secHead{display:flex;justify-content:space-between;align-items:center;padding:12px;border-radius:12px;background:#f8fafc;border:1px solid var(--line);cursor:pointer}
-    .secHead h3{margin:0;font-size:15px}
-    .count{color:var(--muted);font-weight:600}
-    .clients{overflow:hidden;transition:max-height .25s ease}
-    .clients.closed{max-height:0}
-    .clients.open{max-height:360px}
-    .clientRow{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;border-bottom:1px solid var(--line);font-size:14px}
-    .clientRow:last-child{border-bottom:none}
-    .tools{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px}
-    .tool{position:relative;overflow:hidden;border:1px solid var(--line);border-radius:14px;padding:8px 10px;box-shadow:var(--shadow);display:flex;align-items:flex-start;justify-content:flex-start;cursor:pointer;background:#fff;isolation:isolate;height:clamp(72px,22vw,96px);text-decoration:none;color:inherit}
-    .tool:hover{transform:translateY(-1px)}
-    .tTitle{font-weight:700;font-size:14px;line-height:1.1}
-    .mark{position:absolute;right:8px;bottom:6px;font-size:clamp(36px,14vw,56px);opacity:.26;color:var(--licBlue);pointer-events:none}
-    .tool-emoji::after{content:attr(data-emoji);position:absolute;right:8px;bottom:6px;font-size:clamp(36px,14vw,56px);opacity:.28;pointer-events:none}
-    .t-blue{background:linear-gradient(145deg,#e7f0ff,#f7fbff);border-color:#c7d2fe}
-    .t-gold{background:linear-gradient(145deg,#fff1c7,#fff8e4);border-color:#fde68a}
-    .t-teal{background:linear-gradient(145deg,#d9fbef,#f5fffb);border-color:#99f6e4}
-    .t-indigo{background:linear-gradient(145deg,#eaf1ff,#f6f9ff);border-color:#c7d2fe}
-    .t-slate{background:linear-gradient(145deg,#eef2f6,#f8fafc);border-color:#e2e8f0}
-    .t-rose{background:linear-gradient(145deg,#ffe6eb,#fff6f8);border-color:#fecdd3}
-    @media (min-width:720px){.title h1{font-size:20px}}
-    .headerCard{background:linear-gradient(180deg,#fff6d3,#fff9e6);border-color:#f6d36b}
+    body{margin:0;background:#000;color:#00eaff;font-family:Arial,sans-serif;overflow:hidden}
+    #particles{position:fixed;inset:0;z-index:-1}
+    .container{max-width:800px;margin:4rem auto;padding:2rem;background:rgba(255,255,255,.05);border:1px solid rgba(0,234,255,.3);border-radius:20px;backdrop-filter:blur(10px);box-shadow:0 0 20px rgba(0,234,255,.2)}
+    h1{text-align:center;margin-top:0}
+    .contact{text-align:center;margin-top:.5rem}
+    .contact a{color:#00eaff;text-decoration:none;margin:0 .5rem}
+    .contact a:hover{text-shadow:0 0 5px #00eaff}
+    .tools{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;margin-top:2rem}
+    .tool{display:flex;align-items:center;justify-content:center;padding:1.5rem;text-decoration:none;color:#00eaff;background:rgba(0,234,255,.1);border:1px solid #00eaff;border-radius:12px;transition:.3s}
+    .tool:hover{background:rgba(0,234,255,.2);box-shadow:0 0 15px #00eaff}
   </style>
 </head>
 <body>
-  <main class="wrap">
-    <section class="card headerCard">
-      <div class="row">
-        <div class="avatar" id="avatar">
-          <img id="avatarImg" alt="Agent avatar">
-          <span id="avatarInitials">US</span>
-          <input id="avatarFile" type="file" accept="image/*" style="display:none">
-        </div>
-        <div class="title">
-          <h1>Urvi Shah — LIC Insurance Advisor</h1>
-          <div class="contact">
-            <span class="chip">📞 <a href="tel:9428391746">9428391746</a></span>
-            <span class="chip">✉️ <a href="mailto:urvishah2311@gmail.com">urvishah2311@gmail.com</a></span>
-          </div>
-        </div>
-      </div>
-    </section>
-    <div class="space"></div>
-    <section class="card">
-      <div id="clientsToggle" class="secHead" aria-controls="clientsPanel" aria-expanded="false">
-        <h3>Current Clients</h3>
-        <span class="count"><span id="clientCount">0</span></span>
-      </div>
-      <div id="clientsPanel" class="clients closed" role="region" aria-label="Client list">
-        <div id="clientList"></div>
-      </div>
-    </section>
-    <div class="space"></div>
-    <section class="card cardWhite">
-      <div class="tools">
-        <a class="tool t-blue tool-emoji" data-emoji="🎂" href="https://shahssolutions.my.canva.site/age-calculation-tool" target="_blank" rel="noopener" aria-label="Open Age Tool">
-          <div class="tTitle">Age Tool</div>
-        </a>
-        <a class="tool t-gold tool-emoji" data-emoji="🛡️" href="https://shahssolutions.my.canva.site/insurancecalculator" target="_blank" rel="noopener" aria-label="Open Is Your Insurance Enough">
-          <div class="tTitle">Is Your Insurance Enough?</div>
-        </a>
-        <a class="tool t-teal tool-emoji" data-emoji="✨" href="https://shahssolutions.my.canva.site/budgettool" target="_blank" rel="noopener" aria-label="Open Budget & Product Suggestor">
-          <div class="tTitle">Budget & Product Suggestor</div>
-        </a>
-        <a class="tool t-rose tool-emoji" data-emoji="🔔" href="https://shahssolutions.my.canva.site/editable-premium-due-notice-poster" target="_blank" rel="noopener" aria-label="Open Premium Notice Generator">
-          <div class="tTitle">Premium Notice Generator</div>
-        </a>
-      </div>
-    </section>
-    <section class="card">
-      <div id="plansToggle" class="secHead" aria-controls="plansPanel" aria-expanded="false">
-        <h3>Plans</h3>
-        <span class="count">2</span>
-      </div>
-      <div id="plansPanel" class="clients closed" role="region" aria-label="Plan list">
-        <div class="tools plans-grid">
-          <a class="tool t-indigo" href="https://shahssolutions.my.canva.site/733" target="_blank" rel="noopener" aria-label="Open Jeevan Lakhsya 733">
-            <div class="tTitle">Jeevan Lakhsya 733</div>
-            <i class="ti ti-target mark" aria-hidden="true"></i>
-          </a>
-          <a class="tool t-slate" href="https://shahssolutions.my.canva.site/715" target="_blank" rel="noopener" aria-label="Open Jeevan Anand 715">
-            <div class="tTitle">Jeevan Anand 715</div>
-            <i class="ti ti-heart mark" aria-hidden="true"></i>
-          </a>
-        </div>
-      </div>
-    </section>
-  </main>
+  <canvas id="particles"></canvas>
+  <div class="container">
+    <h1>Urvi Shah — LIC Insurance Advisor</h1>
+    <div class="contact">
+      <a href="tel:9428391746">📞 9428391746</a>
+      <a href="mailto:urvishah2311@gmail.com">✉️ urvishah2311@gmail.com</a>
+    </div>
+    <div class="tools">
+      <a href="age-calculator.html" class="tool">Age Calculator</a>
+      <a href="https://shahssolutions.my.canva.site/insurancecalculator" class="tool" target="_blank" rel="noopener">Is Your Insurance Enough?</a>
+      <a href="https://shahssolutions.my.canva.site/budgettool" class="tool" target="_blank" rel="noopener">Budget &amp; Product Suggestor</a>
+      <a href="https://shahssolutions.my.canva.site/editable-premium-due-notice-poster" class="tool" target="_blank" rel="noopener">Premium Notice Generator</a>
+    </div>
+  </div>
   <script>
-    const toggle=document.getElementById('clientsToggle');
-    const panel=document.getElementById('clientsPanel');
-    const count=document.getElementById('clientCount');
-    const list=document.getElementById('clientList');
-    const clients=[];
-    function renderClients(){
-      count.textContent=clients.length;
-      list.innerHTML=clients.map(c=>`<div class=\"clientRow\"><span>${c.name}</span><a href=\"tel:${c.phone}\">📞 ${c.phone}</a></div>`).join('')||`<div class=\"clientRow\" style=\"justify-content:center;color:#64748b\">No clients added yet</div>`
-    }
-    renderClients();
-    toggle.addEventListener('click',()=>{const open=panel.classList.toggle('open');panel.classList.toggle('closed',!open);toggle.setAttribute('aria-expanded',String(open))});
-    const plansToggle=document.getElementById('plansToggle');
-    const plansPanel=document.getElementById('plansPanel');
-    plansToggle.addEventListener('click',()=>{const open=plansPanel.classList.toggle('open');plansPanel.classList.toggle('closed',!open);plansToggle.setAttribute('aria-expanded',String(open))});
-    const avatarEl=document.getElementById('avatar');
-    const avatarImg=document.getElementById('avatarImg');
-    const avatarFile=document.getElementById('avatarFile');
-    const avatarInitials=document.getElementById('avatarInitials');
-    const AVATAR_KEY='lic_toolkit_avatar';
-    function showAvatar(dataURL){if(!dataURL)return;avatarImg.src=dataURL;avatarImg.style.display='block';if(avatarInitials)avatarInitials.style.display='none'}
-    (function(){const saved=localStorage.getItem(AVATAR_KEY);if(saved)showAvatar(saved)})();
-    avatarEl.addEventListener('click',()=>avatarFile.click());
-    avatarFile.addEventListener('change',(e)=>{const file=e.target&&e.target.files&&e.target.files[0]||null;if(!file)return;const reader=new FileReader();reader.onload=()=>{const dataURL=reader.result;showAvatar(dataURL);try{localStorage.setItem(AVATAR_KEY,dataURL)}catch(err){}};reader.readAsDataURL(file)});
+    const canvas=document.getElementById('particles'),ctx=canvas.getContext('2d');
+    function resize(){canvas.width=window.innerWidth;canvas.height=window.innerHeight}
+    window.addEventListener('resize',resize);resize();
+    const particles=[];for(let i=0;i<60;i++){particles.push({x:Math.random()*canvas.width,y:Math.random()*canvas.height,vx:(Math.random()-.5)*.5,vy:(Math.random()-.5)*.5,size:2+Math.random()*2})}
+    function draw(){ctx.clearRect(0,0,canvas.width,canvas.height);particles.forEach(p=>{p.x+=p.vx;p.y+=p.vy;if(p.x<0||p.x>canvas.width)p.vx*=-1;if(p.y<0||p.y>canvas.height)p.vy*=-1;ctx.beginPath();ctx.arc(p.x,p.y,p.size,0,Math.PI*2);ctx.fillStyle='rgba(0,234,255,.5)';ctx.fill()});requestAnimationFrame(draw)}
+    draw();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle toolkit and age calculator with Jarvis-inspired neon blue glass theme and floating particle background
- link Age Calculator button on main page to local `age-calculator.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a01ccbaea08332938c2a8dc9733757