### PR TITLE
Unify Jarvis theme with LIC colors and plan cards

### DIFF
--- a/715/2.html
+++ b/715/2.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LIC Jeevan Anand</title>
+    <link rel="stylesheet" href="../jarvis.css" />
     <!-- Tailwind CSS for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Poppins Font for a consistent look -->
@@ -18,6 +19,11 @@
     </style>
 </head>
 <body class="bg-gray-100">
+    <canvas id="particles"></canvas>
+    <div class="container">
+      <h1 class="jarvis-title">URVI SHAH</h1>
+      <h2 class="jarvis-subtitle">3303</h2>
+    </div>
     <div id="main-container"
         class="relative flex flex-col items-center min-h-screen w-full text-ink font-sans p-4 overflow-x-hidden"
         style="background-image: linear-gradient(to bottom right, #004D99, #001A33);">
@@ -27,6 +33,7 @@
             <!-- Content will be rendered here by JavaScript -->
         </div>
     </div>
+    <script src="../particles.js"></script>
 
     <script>
         // Data model and configuration

--- a/715/index.html
+++ b/715/index.html
@@ -4,13 +4,26 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>LIC Jeevan Anand (715)</title>
+    <link rel="stylesheet" href="../jarvis.css" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react@18/umd/react.production.min.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
+    ></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
   <body class="min-h-screen">
+    <canvas id="particles"></canvas>
+    <div class="container">
+      <h1 class="jarvis-title">URVI SHAH</h1>
+      <h2 class="jarvis-subtitle">3303</h2>
+    </div>
     <div id="root"></div>
+    <script src="../particles.js"></script>
 
     <script type="text/babel">
       const { useEffect, useMemo, useRef, useState } = React;
@@ -33,7 +46,11 @@
             bgSoft: "#F8FAFF",
             success: "#22C55E",
           },
-          style: { look: "modern", effects: ["glassmorphism", "soft-shadows", "rounded-2xl"], emoji_allowed: true },
+          style: {
+            look: "modern",
+            effects: ["glassmorphism", "soft-shadows", "rounded-2xl"],
+            emoji_allowed: true,
+          },
         },
         product: {
           plan_name: "Jeevan Anand",
@@ -42,20 +59,53 @@
         },
         data_model: {
           tiers: [
-            { id: "p1", label: "₹2,600", monthly: 2600, maturity: "₹15,33,000", natural_cover: "₹10,00,000", accidental_cover: "₹15,00,000", lifetime_cover: "₹5,00,000" },
-            { id: "p2", label: "₹5,000", monthly: 5000, maturity: "₹30,66,000", natural_cover: "₹20,00,000", accidental_cover: "₹30,00,000", lifetime_cover: "₹10,00,000" },
-            { id: "p3", label: "₹12,500", monthly: 12500, maturity: "₹76,65,000", natural_cover: "₹50,00,000", accidental_cover: "₹75,00,000", lifetime_cover: "₹25,00,000" },
+            {
+              id: "p1",
+              label: "₹2,600",
+              monthly: 2600,
+              maturity: "₹15,33,000",
+              natural_cover: "₹10,00,000",
+              accidental_cover: "₹15,00,000",
+              lifetime_cover: "₹5,00,000",
+            },
+            {
+              id: "p2",
+              label: "₹5,000",
+              monthly: 5000,
+              maturity: "₹30,66,000",
+              natural_cover: "₹20,00,000",
+              accidental_cover: "₹30,00,000",
+              lifetime_cover: "₹10,00,000",
+            },
+            {
+              id: "p3",
+              label: "₹12,500",
+              monthly: 12500,
+              maturity: "₹76,65,000",
+              natural_cover: "₹50,00,000",
+              accidental_cover: "₹75,00,000",
+              lifetime_cover: "₹25,00,000",
+            },
           ],
           ages: [29, 35, 40, 45, 50, 60, 70, 80, 90, 100],
         },
         screen: {
           layout: [
-            { id: "tierChips", type: "chip-group", position: "top", variant: "pill", size: "large", items_from: "data_model.tiers", active_default: "p2" },
+            {
+              id: "tierChips",
+              type: "chip-group",
+              position: "top",
+              variant: "pill",
+              size: "large",
+              items_from: "data_model.tiers",
+              active_default: "p2",
+            },
             { id: "timeline", type: "horizontal-strip", height_vh: 48 },
           ],
         },
         copy: {
-          disclaimer: "Illustrative. Final benefits as per LIC illustration & proposal at time of purchase.",
+          disclaimer:
+            "Illustrative. Final benefits as per LIC illustration & proposal at time of purchase.",
         },
       };
 
@@ -63,12 +113,17 @@
       const maxAge = 100;
       const leftGutterPct = 7;
       const rightGutterPct = 7;
-      const pctForAge = (age) => leftGutterPct + ((age - minAge) / (maxAge - minAge)) * (100 - leftGutterPct - rightGutterPct);
+      const pctForAge = (age) =>
+        leftGutterPct +
+        ((age - minAge) / (maxAge - minAge)) *
+          (100 - leftGutterPct - rightGutterPct);
       const relPctForAge = (age) => ((age - minAge) / (maxAge - minAge)) * 100;
 
       const usePrevious = (value) => {
         const ref = useRef(value);
-        useEffect(() => { ref.current = value; }, [value]);
+        useEffect(() => {
+          ref.current = value;
+        }, [value]);
         return ref.current;
       };
 
@@ -94,8 +149,17 @@
             const dy = -Math.random() * 260 - 60;
             const rot = (Math.random() - 0.5) * 360;
             dot.animate(
-              [ { transform: "translate(0,0) rotate(0deg)", opacity: 1 }, { transform: `translate(${dx}px, ${dy}px) rotate(${rot}deg)`, opacity: 0 } ],
-              { duration: 1400 + Math.random() * 700, easing: "cubic-bezier(.2,.8,.2,1)" }
+              [
+                { transform: "translate(0,0) rotate(0deg)", opacity: 1 },
+                {
+                  transform: `translate(${dx}px, ${dy}px) rotate(${rot}deg)`,
+                  opacity: 0,
+                },
+              ],
+              {
+                duration: 1400 + Math.random() * 700,
+                easing: "cubic-bezier(.2,.8,.2,1)",
+              },
             );
             setTimeout(() => dot.remove(), 2200);
             frag.appendChild(dot);
@@ -107,26 +171,75 @@
 
       function IconShield({ size = 16, color = "currentColor" }) {
         return (
-          <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ color }}>
-            <path d="M12 3l7 3v5c0 5-3.5 9.3-7 11-3.5-1.7-7-6-7-11V6l7-3z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" fill="none" />
+          <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ color }}
+          >
+            <path
+              d="M12 3l7 3v5c0 5-3.5 9.3-7 11-3.5-1.7-7-6-7-11V6l7-3z"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinejoin="round"
+              fill="none"
+            />
           </svg>
         );
       }
 
       function IconCar({ size = 16, color = "currentColor" }) {
         return (
-          <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ color }}>
-            <path d="M3 13l2-5a3 3 0 012.8-2h8.4A3 3 0 0119 8l2 5v5h-2a2 2 0 01-4 0H9a2 2 0 01-4 0H3v-5z" stroke="currentColor" strokeWidth="1.6" fill="none" strokeLinejoin="round" />
-            <path d="M7 16h10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+          <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ color }}
+          >
+            <path
+              d="M3 13l2-5a3 3 0 012.8-2h8.4A3 3 0 0119 8l2 5v5h-2a2 2 0 01-4 0H9a2 2 0 01-4 0H3v-5z"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              fill="none"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M7 16h10"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
           </svg>
         );
       }
 
       function IconHelp({ size = 16, color = "currentColor" }) {
         return (
-          <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ color }}>
-            <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.8" />
-            <path d="M9.5 9.5a2.5 2.5 0 115 0c0 1.8-2.5 2-2.5 3.8" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+          <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ color }}
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="9"
+              stroke="currentColor"
+              strokeWidth="1.8"
+            />
+            <path
+              d="M9.5 9.5a2.5 2.5 0 115 0c0 1.8-2.5 2-2.5 3.8"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
             <circle cx="12" cy="17" r="1" fill="currentColor" />
           </svg>
         );
@@ -134,31 +247,110 @@
 
       function IconShare({ size = 16, color = "currentColor" }) {
         return (
-          <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ color }}>
-            <path d="M12 3v10" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-            <path d="M9 6l3-3 3 3" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-            <rect x="5" y="11" width="14" height="10" rx="2" stroke="currentColor" strokeWidth="1.8" />
+          <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ color }}
+          >
+            <path
+              d="M12 3v10"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+            />
+            <path
+              d="M9 6l3-3 3 3"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <rect
+              x="5"
+              y="11"
+              width="14"
+              height="10"
+              rx="2"
+              stroke="currentColor"
+              strokeWidth="1.8"
+            />
           </svg>
         );
       }
 
       function IconCalendarCheck({ size = 18, color = "currentColor" }) {
         return (
-          <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ color }}>
-            <rect x="3" y="4" width="18" height="16" rx="2" stroke="currentColor" strokeWidth="1.8" />
-            <path d="M7 2v4M17 2v4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-            <path d="M7 11l3 3 7-7" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+          <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ color }}
+          >
+            <rect
+              x="3"
+              y="4"
+              width="18"
+              height="16"
+              rx="2"
+              stroke="currentColor"
+              strokeWidth="1.8"
+            />
+            <path
+              d="M7 2v4M17 2v4"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+            />
+            <path
+              d="M7 11l3 3 7-7"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </svg>
         );
       }
 
       function IconTrophy({ size = 20, color = "currentColor" }) {
         return (
-          <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ color }}>
-            <path d="M7 4h10v2a5 5 0 01-10 0V4z" stroke="currentColor" strokeWidth="1.6" fill="none" />
-            <path d="M7 4H5a2 2 0 00-2 2v1a5 5 0 005 5" stroke="currentColor" strokeWidth="1.6" fill="none" />
-            <path d="M17 4h2a2 2 0 012 2v1a5 5 0 01-5 5" stroke="currentColor" strokeWidth="1.6" fill="none" />
-            <path d="M9 14h6v3H9z" stroke="currentColor" strokeWidth="1.6" fill="none" />
+          <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ color }}
+          >
+            <path
+              d="M7 4h10v2a5 5 0 01-10 0V4z"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              fill="none"
+            />
+            <path
+              d="M7 4H5a2 2 0 00-2 2v1a5 5 0 005 5"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              fill="none"
+            />
+            <path
+              d="M17 4h2a2 2 0 012 2v1a5 5 0 01-5 5"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              fill="none"
+            />
+            <path
+              d="M9 14h6v3H9z"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              fill="none"
+            />
             <path d="M7 20h10" stroke="currentColor" strokeWidth="1.6" />
           </svg>
         );
@@ -166,18 +358,60 @@
 
       function IconHeart({ size = 16, color = "currentColor" }) {
         return (
-          <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ color }}>
-            <path d="M12 21s-7-4.5-9-8a5.2 5.2 0 019-5 5.2 5.2 0 019 5c-2 3.5-9 8-9 8z" stroke="currentColor" strokeWidth="1.6" fill="none" strokeLinejoin="round" />
+          <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ color }}
+          >
+            <path
+              d="M12 21s-7-4.5-9-8a5.2 5.2 0 019-5 5.2 5.2 0 019 5c-2 3.5-9 8-9 8z"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              fill="none"
+              strokeLinejoin="round"
+            />
           </svg>
         );
       }
 
       function IconFirstAid({ size = 16, color = "currentColor" }) {
         return (
-          <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ color }}>
-            <rect x="3" y="7" width="18" height="12" rx="2" stroke="currentColor" strokeWidth="1.8" fill="none" />
-            <rect x="8" y="4" width="8" height="3" rx="1.5" stroke="currentColor" strokeWidth="1.6" />
-            <path d="M12 10v6M9 13h6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+          <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{ color }}
+          >
+            <rect
+              x="3"
+              y="7"
+              width="18"
+              height="12"
+              rx="2"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              fill="none"
+            />
+            <rect
+              x="8"
+              y="4"
+              width="8"
+              height="3"
+              rx="1.5"
+              stroke="currentColor"
+              strokeWidth="1.6"
+            />
+            <path
+              d="M12 10v6M9 13h6"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+            />
           </svg>
         );
       }
@@ -194,7 +428,9 @@
               background: active ? p.licBlue : "#fff",
               color: active ? "#fff" : p.ink,
               borderColor: active ? p.licGold : p.border,
-              boxShadow: active ? "0 8px 20px rgba(11,78,162,0.25)" : "0 4px 12px rgba(11,21,48,0.06)",
+              boxShadow: active
+                ? "0 8px 20px rgba(11,78,162,0.25)"
+                : "0 4px 12px rgba(11,21,48,0.06)",
             }}
           >
             <span>{label}</span>
@@ -206,9 +442,29 @@
         const p = config.brand.palette;
         const left = pctForAge(age);
         return (
-          <button aria-label={`Age ${age}`} onClick={onClick} className="absolute" style={{ left: `${left}%`, top: `${baselinePct}%`, transform: "translate(-50%, 0)" }}>
-            <div style={{ width: 1, height: 12, background: selected ? p.licGold : p.border }} />
-            <div className="mt-1 text-[12px] font-semibold" style={{ color: selected ? p.licBlue : p.ink }}>{age}</div>
+          <button
+            aria-label={`Age ${age}`}
+            onClick={onClick}
+            className="absolute"
+            style={{
+              left: `${left}%`,
+              top: `${baselinePct}%`,
+              transform: "translate(-50%, 0)",
+            }}
+          >
+            <div
+              style={{
+                width: 1,
+                height: 12,
+                background: selected ? p.licGold : p.border,
+              }}
+            />
+            <div
+              className="mt-1 text-[12px] font-semibold"
+              style={{ color: selected ? p.licBlue : p.ink }}
+            >
+              {age}
+            </div>
           </button>
         );
       }
@@ -217,27 +473,53 @@
         const p = config.brand.palette;
         if (segment === "pay") {
           return (
-            <div className="rounded-2xl border p-3 grid grid-cols-3 gap-2" style={{ background: "#fff", borderColor: p.border }}>
+            <div
+              className="rounded-2xl border p-3 grid grid-cols-3 gap-2"
+              style={{ background: "#fff", borderColor: p.border }}
+            >
               <div className="flex items-center gap-2">
                 <IconCalendarCheck size={16} color={p.licBlue} />
-                <div className="text-[12px] font-semibold" style={{ color: p.ink }}>Monthly Premium: ₹{tier.monthly}</div>
+                <div
+                  className="text-[12px] font-semibold"
+                  style={{ color: p.ink }}
+                >
+                  Monthly Premium: ₹{tier.monthly}
+                </div>
               </div>
               <div className="flex items-center gap-2">
                 <IconHeart size={14} color={p.licBlue} />
-                <div className="text-[12px] font-semibold" style={{ color: p.ink }}>Risk Cover: {tier.natural_cover}</div>
+                <div
+                  className="text-[12px] font-semibold"
+                  style={{ color: p.ink }}
+                >
+                  Risk Cover: {tier.natural_cover}
+                </div>
               </div>
               <div className="flex items-center gap-2">
                 <IconFirstAid size={14} color={p.licBlue} />
-                <div className="text-[12px] font-semibold" style={{ color: p.ink }}>Accidental Cover: {tier.accidental_cover}</div>
+                <div
+                  className="text-[12px] font-semibold"
+                  style={{ color: p.ink }}
+                >
+                  Accidental Cover: {tier.accidental_cover}
+                </div>
               </div>
             </div>
           );
         }
         return (
-          <div className="rounded-2xl border p-3" style={{ background: "#fff", borderColor: p.border }}>
+          <div
+            className="rounded-2xl border p-3"
+            style={{ background: "#fff", borderColor: p.border }}
+          >
             <div className="flex items-center gap-2">
               <IconShield size={16} color={p.licBlue} />
-              <div className="text-[12px] font-semibold" style={{ color: p.ink }}>Death Cover: {tier.lifetime_cover}</div>
+              <div
+                className="text-[12px] font-semibold"
+                style={{ color: p.ink }}
+              >
+                Death Cover: {tier.lifetime_cover}
+              </div>
             </div>
           </div>
         );
@@ -245,16 +527,39 @@
 
       function JeevanAnand715Interactive() {
         const p = config.brand.palette;
-        const [activeTierId, setActiveTierId] = useState(config.screen.layout[0].active_default);
+        const [activeTierId, setActiveTierId] = useState(
+          config.screen.layout[0].active_default,
+        );
         const [selectedAge, setSelectedAge] = useState(35);
         const prevAge = usePrevious(selectedAge);
         const canvasRef = useRef(null);
 
-        const activeTier = useMemo(() => (config.data_model.tiers.find((t) => t.id === activeTierId) || config.data_model.tiers[0]), [activeTierId]);
+        const activeTier = useMemo(
+          () =>
+            config.data_model.tiers.find((t) => t.id === activeTierId) ||
+            config.data_model.tiers[0],
+          [activeTierId],
+        );
 
-        const { burst, doneRef } = useConfetti({ containerRef: canvasRef, colors: [p.licGold, p.licBlue, "#22c55e", "#60a5fa", "#a78bfa", "#ef4444"], count: 90 });
+        const { burst, doneRef } = useConfetti({
+          containerRef: canvasRef,
+          colors: [
+            p.licGold,
+            p.licBlue,
+            "#22c55e",
+            "#60a5fa",
+            "#a78bfa",
+            "#ef4444",
+          ],
+          count: 90,
+        });
 
-        useEffect(() => { if (selectedAge === 50 && prevAge !== 50 && !doneRef.current) { burst(); doneRef.current = true; } }, [selectedAge, prevAge, burst, doneRef]);
+        useEffect(() => {
+          if (selectedAge === 50 && prevAge !== 50 && !doneRef.current) {
+            burst();
+            doneRef.current = true;
+          }
+        }, [selectedAge, prevAge, burst, doneRef]);
 
         const railHeightVH = config.screen.layout[1].height_vh;
 
@@ -278,17 +583,53 @@
         })();
 
         return (
-          <div ref={canvasRef} className="w-screen h-screen overflow-hidden" style={{ background: `linear-gradient(135deg, ${p.bgSoft}, #ffffff)`, color: p.ink, fontFamily: "Inter, system-ui, -apple-system, Segoe UI, Roboto" }} aria-label={`${config.product.plan_name} pitch screen`}>
+          <div
+            ref={canvasRef}
+            className="w-screen h-screen overflow-hidden"
+            style={{
+              background: `linear-gradient(135deg, ${p.bgSoft}, #ffffff)`,
+              color: p.ink,
+              fontFamily: "Inter, system-ui, -apple-system, Segoe UI, Roboto",
+            }}
+            aria-label={`${config.product.plan_name} pitch screen`}
+          >
             <div className="px-3 pt-2 flex items-center justify-between gap-2">
               <div className="flex items-center gap-2">
-                <div className="w-8 h-8 rounded-full flex items-center justify-center text-[10px] font-black" style={{ background: p.licBlue, color: "#fff", boxShadow: "0 6px 16px rgba(11,78,162,0.25)" }}>LIC</div>
-                <div className="text-xs font-semibold" style={{ color: p.ink }}>{config.product.plan_name} • {config.product.plan_code}</div>
+                <div
+                  className="w-8 h-8 rounded-full flex items-center justify-center text-[10px] font-black"
+                  style={{
+                    background: p.licBlue,
+                    color: "#fff",
+                    boxShadow: "0 6px 16px rgba(11,78,162,0.25)",
+                  }}
+                >
+                  LIC
+                </div>
+                <div className="text-xs font-semibold" style={{ color: p.ink }}>
+                  {config.product.plan_name} • {config.product.plan_code}
+                </div>
               </div>
               <div className="flex items-center gap-1">
-                <button aria-label="Help" className="w-8 h-8 rounded-full border flex items-center justify-center" style={{ background: "#fff", borderColor: p.border, color: p.muted }}>
+                <button
+                  aria-label="Help"
+                  className="w-8 h-8 rounded-full border flex items-center justify-center"
+                  style={{
+                    background: "#fff",
+                    borderColor: p.border,
+                    color: p.muted,
+                  }}
+                >
                   <IconHelp size={16} />
                 </button>
-                <button aria-label="Share" className="w-8 h-8 rounded-full border flex items-center justify-center" style={{ background: "#fff", borderColor: p.border, color: p.muted }}>
+                <button
+                  aria-label="Share"
+                  className="w-8 h-8 rounded-full border flex items-center justify-center"
+                  style={{
+                    background: "#fff",
+                    borderColor: p.border,
+                    color: p.muted,
+                  }}
+                >
                   <IconShare size={16} />
                 </button>
               </div>
@@ -297,10 +638,25 @@
             <div className="px-3 mt-2">
               <div className="flex items-start gap-3">
                 <div className="flex-1">
-                  <div className="text-xs font-bold mb-1" style={{ color: p.ink }}>Choose Monthly Premium</div>
-                  <div className="flex items-center gap-2" role="group" aria-label="Monthly premium tier">
+                  <div
+                    className="text-xs font-bold mb-1"
+                    style={{ color: p.ink }}
+                  >
+                    Choose Monthly Premium
+                  </div>
+                  <div
+                    className="flex items-center gap-2"
+                    role="group"
+                    aria-label="Monthly premium tier"
+                  >
                     {config.data_model.tiers.map((t) => (
-                      <Chip key={t.id} ariaLabel={`Monthly premium ${t.label}`} active={activeTierId === t.id} label={t.label} onClick={() => setActiveTierId(t.id)} />
+                      <Chip
+                        key={t.id}
+                        ariaLabel={`Monthly premium ${t.label}`}
+                        active={activeTierId === t.id}
+                        label={t.label}
+                        onClick={() => setActiveTierId(t.id)}
+                      />
                     ))}
                   </div>
                 </div>
@@ -308,47 +664,171 @@
             </div>
 
             <div className="px-3 mt-3">
-              <div className="text-xs font-semibold mb-2" style={{ color: p.muted }}>{config.product.tagline}</div>
-              <div className="relative rounded-2xl" aria-label="Plan timeline" style={{ height: `${railHeightVH}vh`, background: "#fff", boxShadow: "inset 0 0 0 1px rgba(238,210,123,0.9)", overflow: "hidden" }}>
-                <div className="absolute left-[7%] right-[7%] top-1/2 -translate-y-1/2 h-[24px] rounded-full" style={{ background: "#EEF2FF" }} />
-                <button aria-label="Premium segment" className="absolute top-1/2 -translate-y-1/2 h-[24px] rounded-l-full text-[10px] font-bold tracking-wide uppercase flex items-center justify-center"
-                  style={{ left: `${relStart}%`, width: `${relFifty - relStart}%`, backgroundColor: p.success, color: "#0b1a2a", backgroundImage: `${rupeePattern}`, backgroundSize: "20px 20px", backgroundRepeat: "repeat" }}
+              <div
+                className="text-xs font-semibold mb-2"
+                style={{ color: p.muted }}
+              >
+                {config.product.tagline}
+              </div>
+              <div
+                className="relative rounded-2xl"
+                aria-label="Plan timeline"
+                style={{
+                  height: `${railHeightVH}vh`,
+                  background: "#fff",
+                  boxShadow: "inset 0 0 0 1px rgba(238,210,123,0.9)",
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  className="absolute left-[7%] right-[7%] top-1/2 -translate-y-1/2 h-[24px] rounded-full"
+                  style={{ background: "#EEF2FF" }}
+                />
+                <button
+                  aria-label="Premium segment"
+                  className="absolute top-1/2 -translate-y-1/2 h-[24px] rounded-l-full text-[10px] font-bold tracking-wide uppercase flex items-center justify-center"
+                  style={{
+                    left: `${relStart}%`,
+                    width: `${relFifty - relStart}%`,
+                    backgroundColor: p.success,
+                    color: "#0b1a2a",
+                    backgroundImage: `${rupeePattern}`,
+                    backgroundSize: "20px 20px",
+                    backgroundRepeat: "repeat",
+                  }}
                   onClick={() => setSelectedAge(35)}
                 >
                   Premium Payments
                 </button>
-                <button aria-label="Coverage segment" className="absolute top-1/2 -translate-y-1/2 h-[24px] rounded-r-full text-[10px] font-bold tracking-wide uppercase flex items-center justify-center"
-                  style={{ left: `${relFifty}%`, width: `${relEnd - relFifty}%`, backgroundColor: p.railBlue2, color: "#fff", backgroundImage: `${shieldPattern}`, backgroundSize: "22px 22px", backgroundRepeat: "repeat" }}
+                <button
+                  aria-label="Coverage segment"
+                  className="absolute top-1/2 -translate-y-1/2 h-[24px] rounded-r-full text-[10px] font-bold tracking-wide uppercase flex items-center justify-center"
+                  style={{
+                    left: `${relFifty}%`,
+                    width: `${relEnd - relFifty}%`,
+                    backgroundColor: p.railBlue2,
+                    color: "#fff",
+                    backgroundImage: `${shieldPattern}`,
+                    backgroundSize: "22px 22px",
+                    backgroundRepeat: "repeat",
+                  }}
                   onClick={() => setSelectedAge(60)}
                 >
                   Lifetime Coverage
                 </button>
-                <div className="absolute" style={{ left: `${fiftyPct}%`, top: "28%", bottom: "28%", transform: "translateX(-50%)" }}>
-                  <div className="w-0.5 h-full" style={{ background: p.licGold }} />
+                <div
+                  className="absolute"
+                  style={{
+                    left: `${fiftyPct}%`,
+                    top: "28%",
+                    bottom: "28%",
+                    transform: "translateX(-50%)",
+                  }}
+                >
+                  <div
+                    className="w-0.5 h-full"
+                    style={{ background: p.licGold }}
+                  />
                 </div>
-                <div className="absolute" style={{ left: `${startPct}%`, top: "30%", transform: "translate(-50%, -100%)" }}>
-                  <div className="w-8 h-8 rounded-full flex items-center justify-center" style={{ background: "#fff", border: `1px solid ${p.border}`, boxShadow: "0 6px 16px rgba(0,0,0,0.08)" }}>
+                <div
+                  className="absolute"
+                  style={{
+                    left: `${startPct}%`,
+                    top: "30%",
+                    transform: "translate(-50%, -100%)",
+                  }}
+                >
+                  <div
+                    className="w-8 h-8 rounded-full flex items-center justify-center"
+                    style={{
+                      background: "#fff",
+                      border: `1px solid ${p.border}`,
+                      boxShadow: "0 6px 16px rgba(0,0,0,0.08)",
+                    }}
+                  >
                     <IconCalendarCheck size={18} color={p.licBlue} />
                   </div>
                 </div>
-                <div className="absolute" style={{ left: `${startPct}%`, top: "72%", transform: "translate(-50%, 0)" }}>
-                  <div className="text-[11px] font-semibold" style={{ color: p.ink }}>₹{activeTier.monthly}/month</div>
+                <div
+                  className="absolute"
+                  style={{
+                    left: `${startPct}%`,
+                    top: "72%",
+                    transform: "translate(-50%, 0)",
+                  }}
+                >
+                  <div
+                    className="text-[11px] font-semibold"
+                    style={{ color: p.ink }}
+                  >
+                    ₹{activeTier.monthly}/month
+                  </div>
                 </div>
-                <div className="absolute" style={{ left: `${fiftyPct}%`, top: "18%", transform: "translate(-50%, 0)" }}>
-                  <div className="w-9 h-9 rounded-full flex items-center justify-center" style={{ background: p.licGold, color: "#111827", boxShadow: "0 8px 18px rgba(245,193,61,0.35)" }}>
+                <div
+                  className="absolute"
+                  style={{
+                    left: `${fiftyPct}%`,
+                    top: "18%",
+                    transform: "translate(-50%, 0)",
+                  }}
+                >
+                  <div
+                    className="w-9 h-9 rounded-full flex items-center justify-center"
+                    style={{
+                      background: p.licGold,
+                      color: "#111827",
+                      boxShadow: "0 8px 18px rgba(245,193,61,0.35)",
+                    }}
+                  >
                     <IconTrophy size={20} color="#111827" />
                   </div>
                 </div>
-                <div className="absolute" style={{ left: `${fiftyPct}%`, top: "24%", transform: "translate(-50%, -100%)" }}>
-                  <div className="rounded-md border px-2 py-1 text-[11px] font-semibold" style={{ background: "#fff", color: p.ink, borderColor: p.border }}>Maturity & Premiums Stop</div>
+                <div
+                  className="absolute"
+                  style={{
+                    left: `${fiftyPct}%`,
+                    top: "24%",
+                    transform: "translate(-50%, -100%)",
+                  }}
+                >
+                  <div
+                    className="rounded-md border px-2 py-1 text-[11px] font-semibold"
+                    style={{
+                      background: "#fff",
+                      color: p.ink,
+                      borderColor: p.border,
+                    }}
+                  >
+                    Maturity & Premiums Stop
+                  </div>
                 </div>
-                <div className="absolute" style={{ left: `${fiftyPct + (endPct - fiftyPct) * 0.04}%`, top: "52%", transform: "translate(-50%, -50%)" }}>
-                  <div className="w-7 h-7 rounded-full flex items-center justify-center" style={{ background: "#fff", border: `1px solid ${p.border}`, boxShadow: "0 6px 16px rgba(0,0,0,0.08)" }}>
+                <div
+                  className="absolute"
+                  style={{
+                    left: `${fiftyPct + (endPct - fiftyPct) * 0.04}%`,
+                    top: "52%",
+                    transform: "translate(-50%, -50%)",
+                  }}
+                >
+                  <div
+                    className="w-7 h-7 rounded-full flex items-center justify-center"
+                    style={{
+                      background: "#fff",
+                      border: `1px solid ${p.border}`,
+                      boxShadow: "0 6px 16px rgba(0,0,0,0.08)",
+                    }}
+                  >
                     <IconShield size={16} color={p.licBlue} />
                   </div>
                 </div>
                 {config.data_model.ages.map((age) => (
-                  <Tick key={age} age={age} selected={age === selectedAge} onClick={() => setSelectedAge(age)} baselinePct={78} />
+                  <Tick
+                    key={age}
+                    age={age}
+                    selected={age === selectedAge}
+                    onClick={() => setSelectedAge(age)}
+                    baselinePct={78}
+                  />
                 ))}
               </div>
               <div className="mt-2">
@@ -357,45 +837,112 @@
             </div>
 
             <div className="px-3 mt-3">
-              <div className="rounded-2xl border p-3" style={{ background: p.card, borderColor: p.border }}>
+              <div
+                className="rounded-2xl border p-3"
+                style={{ background: p.card, borderColor: p.border }}
+              >
                 <div className="grid grid-cols-4 gap-2 items-end">
                   <div className="col-span-2">
-                    <div className="text-[11px] font-semibold" style={{ color: p.muted }}>Total Maturity Benefit</div>
-                    <div className="text-2xl font-extrabold flex items-center gap-2" style={{ color: p.licBlue }}>
+                    <div
+                      className="text-[11px] font-semibold"
+                      style={{ color: p.muted }}
+                    >
+                      Total Maturity Benefit
+                    </div>
+                    <div
+                      className="text-2xl font-extrabold flex items-center gap-2"
+                      style={{ color: p.licBlue }}
+                    >
                       <span>{activeTier.maturity}</span>
                     </div>
                   </div>
                   <div className="flex items-start gap-2">
                     <IconHeart size={14} color={p.licBlue} />
                     <div>
-                      <div className="text-[11px] font-semibold" style={{ color: p.muted }}>Life Cover</div>
-                      <div className="text-base font-bold" style={{ color: p.ink }}>{activeTier.natural_cover}</div>
+                      <div
+                        className="text-[11px] font-semibold"
+                        style={{ color: p.muted }}
+                      >
+                        Life Cover
+                      </div>
+                      <div
+                        className="text-base font-bold"
+                        style={{ color: p.ink }}
+                      >
+                        {activeTier.natural_cover}
+                      </div>
                     </div>
                   </div>
                   <div className="flex items-start gap-2">
                     <IconCar size={14} color={p.licBlue} />
                     <div>
-                      <div className="text-[11px] font-semibold" style={{ color: p.muted }}>Accident Cover</div>
-                      <div className="text-base font-bold" style={{ color: p.ink }}>{activeTier.accidental_cover}</div>
+                      <div
+                        className="text-[11px] font-semibold"
+                        style={{ color: p.muted }}
+                      >
+                        Accident Cover
+                      </div>
+                      <div
+                        className="text-base font-bold"
+                        style={{ color: p.ink }}
+                      >
+                        {activeTier.accidental_cover}
+                      </div>
                     </div>
                   </div>
                   <div className="flex items-start gap-2">
                     <IconCalendarCheck size={14} color={p.licBlue} />
                     <div>
-                      <div className="text-[11px] font-semibold" style={{ color: p.muted }}>Monthly Premium</div>
-                      <div className="text-base font-bold" style={{ color: p.ink }}>₹{activeTier.monthly}</div>
+                      <div
+                        className="text-[11px] font-semibold"
+                        style={{ color: p.muted }}
+                      >
+                        Monthly Premium
+                      </div>
+                      <div
+                        className="text-base font-bold"
+                        style={{ color: p.ink }}
+                      >
+                        ₹{activeTier.monthly}
+                      </div>
                     </div>
                   </div>
                 </div>
                 <div className="mt-3 flex items-center gap-2">
-                  <button className="px-3 h-9 rounded-full text-xs font-semibold" style={{ background: p.licGold, color: "#111827", boxShadow: "0 6px 16px rgba(245,193,61,0.35)" }}>Get Personalized Quote</button>
-                  <button className="px-3 h-9 rounded-full text-xs font-semibold border" style={{ background: "#fff", color: p.ink, borderColor: p.border }}>Talk to an Advisor</button>
+                  <button
+                    className="px-3 h-9 rounded-full text-xs font-semibold"
+                    style={{
+                      background: p.licGold,
+                      color: "#111827",
+                      boxShadow: "0 6px 16px rgba(245,193,61,0.35)",
+                    }}
+                  >
+                    Get Personalized Quote
+                  </button>
+                  <button
+                    className="px-3 h-9 rounded-full text-xs font-semibold border"
+                    style={{
+                      background: "#fff",
+                      color: p.ink,
+                      borderColor: p.border,
+                    }}
+                  >
+                    Talk to an Advisor
+                  </button>
                 </div>
               </div>
             </div>
 
-            <div className="mt-3" style={{ borderTop: `1px solid ${p.border}` }}>
-              <div className="px-3 py-2 text-[11px] italic text-center" style={{ color: p.muted }}>{config.copy.disclaimer}</div>
+            <div
+              className="mt-3"
+              style={{ borderTop: `1px solid ${p.border}` }}
+            >
+              <div
+                className="px-3 py-2 text-[11px] italic text-center"
+                style={{ color: p.muted }}
+              >
+                {config.copy.disclaimer}
+              </div>
             </div>
           </div>
         );
@@ -406,4 +953,3 @@
     </script>
   </body>
 </html>
-

--- a/age-calculator.html
+++ b/age-calculator.html
@@ -4,40 +4,35 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Age Calculator</title>
+  <link rel="stylesheet" href="jarvis.css"/>
   <style>
-    body{margin:0;background:#000;color:#00eaff;font-family:Arial,sans-serif;overflow:hidden}
-    #particles{position:fixed;inset:0;z-index:-1}
-    .container{max-width:600px;margin:4rem auto;padding:2rem;background:rgba(255,255,255,.05);border:1px solid rgba(0,234,255,.3);border-radius:20px;backdrop-filter:blur(10px);box-shadow:0 0 20px rgba(0,234,255,.2)}
-    h1{text-align:center;margin-top:0}
     label{display:block;margin-top:1rem;margin-bottom:.5rem}
-    input{width:100%;padding:.8rem;background:rgba(0,0,0,.4);border:1px solid #00eaff;border-radius:8px;color:#00eaff}
-    input:focus{outline:none;box-shadow:0 0 10px #00eaff}
-    .result{margin-top:1rem;font-size:1.2rem}
+    input{width:100%;padding:.8rem;background:rgba(0,0,0,0.4);border:1px solid var(--accent);border-radius:8px;color:var(--accent)}
+    input:focus{outline:none;box-shadow:0 0 10px var(--accent)}
   </style>
 </head>
 <body>
   <canvas id="particles"></canvas>
   <div class="container">
-    <h1>🎂 Age Calculator</h1>
-    <label for="birthDate">Enter your birth date (DDMMYYYY):</label>
-    <input type="text" id="birthDate" maxlength="8" placeholder="02011996" oninput="formatDateInput(this);calculateAge();">
-    <div id="ageToday" class="result">Please enter your birth date</div>
-    <hr style="border-color:rgba(0,234,255,.2);margin:2rem 0;">
-    <label for="customDate">Enter a date (DDMMYYYY):</label>
-    <input type="text" id="customDate" maxlength="8" placeholder="15062024" oninput="formatDateInput(this);calculateAge();">
-    <div id="ageOnDate" class="result">Select a date to see your age</div>
-    <div id="additionalInfo" style="display:none;margin-top:2rem;">
-      <h3>Fun Facts:</h3>
-      <div id="funFacts"></div>
+    <h1 class="jarvis-title">URVI SHAH</h1>
+    <h2 class="jarvis-subtitle">3303</h2>
+    <div class="card-container" style="max-width:600px;">
+      <h1>🎂 Age Calculator</h1>
+      <label for="birthDate">Enter your birth date (DDMMYYYY):</label>
+      <input type="text" id="birthDate" maxlength="8" placeholder="02011996" oninput="formatDateInput(this);calculateAge();">
+      <div id="ageToday" class="result">Please enter your birth date</div>
+      <hr>
+      <label for="customDate">Enter a date (DDMMYYYY):</label>
+      <input type="text" id="customDate" maxlength="8" placeholder="15062024" oninput="formatDateInput(this);calculateAge();">
+      <div id="ageOnDate" class="result">Select a date to see your age</div>
+      <div id="additionalInfo" style="display:none;margin-top:2rem;">
+        <h3>Fun Facts:</h3>
+        <div id="funFacts"></div>
+      </div>
     </div>
   </div>
+  <script src="particles.js"></script>
   <script>
-    const canvas=document.getElementById('particles'),ctx=canvas.getContext('2d');
-    function resize(){canvas.width=window.innerWidth;canvas.height=window.innerHeight}
-    window.addEventListener('resize',resize);resize();
-    const particles=[];for(let i=0;i<60;i++){particles.push({x:Math.random()*canvas.width,y:Math.random()*canvas.height,vx:(Math.random()-.5)*.5,vy:(Math.random()-.5)*.5,size:2+Math.random()*2})}
-    function draw(){ctx.clearRect(0,0,canvas.width,canvas.height);particles.forEach(p=>{p.x+=p.vx;p.y+=p.vy;if(p.x<0||p.x>canvas.width)p.vx*=-1;if(p.y<0||p.y>canvas.height)p.vy*=-1;ctx.beginPath();ctx.arc(p.x,p.y,p.size,0,Math.PI*2);ctx.fillStyle='rgba(0,234,255,.5)';ctx.fill()});requestAnimationFrame(draw)}
-    draw();
     function formatDateInput(input){input.value=input.value.replace(/[^0-9]/g,'')}
     function parseCustomDate(str){if(str.length!==8)return null;const d=parseInt(str.slice(0,2)),m=parseInt(str.slice(2,4)),y=parseInt(str.slice(4,8));if(d<1||d>31||m<1||m>12||y<1900||y>2100)return null;const date=new Date(y,m-1,d);if(date.getDate()!==d||date.getMonth()!==m-1||date.getFullYear()!==y)return null;return date}
     function calculateAge(){const birth=document.getElementById('birthDate'),custom=document.getElementById('customDate'),todayDiv=document.getElementById('ageToday'),onDateDiv=document.getElementById('ageOnDate'),info=document.getElementById('additionalInfo'),facts=document.getElementById('funFacts');if(!birth.value||birth.value.length!==8){todayDiv.textContent='Please enter your birth date (8 digits)';onDateDiv.textContent='Select a date to see your age';info.style.display='none';return}const birthDate=parseCustomDate(birth.value);if(!birthDate){todayDiv.innerHTML='<span style="color:#ff4d4d;">Invalid birth date format!</span>';onDateDiv.textContent='Select a date to see your age';info.style.display='none';return}const today=new Date();todayDiv.innerHTML=formatAge(calculateAgeDetails(birthDate,today));if(custom.value&&custom.value.length===8){const customDate=parseCustomDate(custom.value);if(!customDate){onDateDiv.innerHTML='<span style="color:#ff4d4d;">Invalid date format!</span>'}else if(customDate<birthDate){onDateDiv.innerHTML='<span style="color:#ff4d4d;">Date is before birth date!</span>'}else{onDateDiv.innerHTML=formatAge(calculateAgeDetails(birthDate,customDate))}}else{onDateDiv.textContent='Select a date to see your age'}showFunFacts(birthDate,today,facts);info.style.display='block'}

--- a/index.html
+++ b/index.html
@@ -4,66 +4,13 @@
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <title>Client Manager</title>
-<style>
-  :root{
-    --bg:#0b0f14; --card:rgba(255,255,255,0.06); --cardBorder:rgba(255,255,255,0.12);
-    --text:#e8f7ff; --muted:#9fb6c3; --accent:#00e6ff;
-    --ok:#19d27a; --warn:#ffb020; --err:#ff4d4d;
-    --glow:0 0 18px rgba(0,230,255,0.55);
-  }
-  *{box-sizing:border-box}
-  body{margin:0;font-family:system-ui,Segoe UI,Inter,Roboto,Arial;background:radial-gradient(1200px 900px at 10% 10%,#0e1420 0%,#0b0f14 60%,#090c11 100%);color:var(--text)}
-  .container{max-width:1100px;margin:28px auto;padding:0 16px}
-  .alert{margin-bottom:10px;padding:10px 12px;border-radius:10px;border:1px solid var(--cardBorder);background:rgba(255,255,255,0.06);display:none}
-  .alert.err{border-color:#ff4d4d33}
-  .panel{background:var(--card);border:1px solid var(--cardBorder);backdrop-filter:blur(10px);border-radius:16px;overflow:hidden;box-shadow:0 6px 22px rgba(0,0,0,0.35)}
-  .header{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--cardBorder)}
-  .clickable{cursor:pointer;user-select:none}
-  .title{display:flex;align-items:center;gap:10px;font-weight:700;letter-spacing:.2px;text-shadow:var(--glow)}
-  .dot{width:8px;height:8px;border-radius:50%;background:var(--accent);box-shadow:var(--glow)}
-  .actions{display:flex;gap:8px;align-items:center}
-  .btn{border:1px solid var(--cardBorder);background:rgba(255,255,255,0.05);color:var(--text);padding:8px 12px;border-radius:10px;cursor:pointer}
-  .btn.neon{border-color:rgba(0,230,255,.5);color:#c8f9ff;box-shadow:var(--glow)}
-  .btn:disabled{opacity:.6;cursor:not-allowed}
-  .badge{min-width:28px;height:28px;padding:0 10px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;border:1px solid rgba(0,230,255,.35);background:linear-gradient(to bottom right,rgba(0,230,255,.18),rgba(0,230,255,.05));font-weight:700;color:#c8f9ff;box-shadow:var(--glow)}
-  .content{padding:8px 0}
-  .hide{display:none}
-
-  .table-wrap{overflow:auto;max-height:58vh}
-  table{width:100%;border-collapse:collapse;font-size:14px;table-layout:fixed}
-  th,td{padding:12px 14px;border-bottom:1px solid var(--cardBorder);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  th{position:sticky;top:0;background:rgba(8,12,18,0.8);backdrop-filter:blur(6px);text-align:left;color:#cfe6f1}
-  tr{transition:background .2s}
-  tr:hover{background:rgba(255,255,255,0.05)}
-  .muted{color:var(--muted)}
-  .pill{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;border:1px solid var(--cardBorder);background:rgba(255,255,255,0.05);font-size:12px}
-
-  /* Inline profile drawer */
-  .drawer{border-top:1px solid var(--cardBorder);background:rgba(255,255,255,0.04)}
-  .drawer-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:1px solid var(--cardBorder)}
-  .section-title{margin:10px 16px 4px;font-weight:700;font-size:14px;color:#d9f6ff}
-  .form{display:grid;gap:10px;padding:14px 16px}
-  .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
-  label{font-size:12px;color:#b7c7d1}
-  input,select,textarea{width:100%;padding:10px 12px;border-radius:10px;border:1px solid var(--cardBorder);background:rgba(255,255,255,0.04);color:var(--text);outline:none}
-  .list{padding:6px 16px 16px;display:grid;gap:10px}
-  .policy{display:grid;gap:6px;padding:10px;border:1px dashed var(--cardBorder);border-radius:12px}
-  .hint{font-size:12px;color:var(--muted)}
-  .ok{color:var(--ok)} .warn{color:var(--warn)} .err{color:var(--err)}
-
-  /* Tools */
-  .tools{margin-top:16px}
-  .tools-grid{padding:16px;display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
-  .tool-card{border:1px dashed var(--cardBorder);border-radius:12px;padding:16px;min-height:90px;display:flex;align-items:center;justify-content:center;color:var(--muted);text-decoration:none}
-
-  /* Modal */
-  .backdrop{position:fixed;inset:0;background:rgba(0,0,0,0.5);display:none;align-items:center;justify-content:center;z-index:50}
-  .backdrop.show{display:flex}
-  .modal-panel{width:min(650px,92vw)}
-</style>
+<link rel="stylesheet" href="jarvis.css"/>
 </head>
 <body>
+<canvas id="particles"></canvas>
 <div class="container">
+  <h1 class="jarvis-title">URVI SHAH</h1>
+  <h2 class="jarvis-subtitle">3303</h2>
   <div id="alert" class="alert err"></div>
 
   <!-- Clients (single column) -->
@@ -110,10 +57,20 @@
       <div class="title"><span class="dot"></span> Tools</div>
     </div>
     <div class="tools-grid">
-      <a href="age-calculator.html" class="tool-card">Age Calculator</a>
-      <a href="https://shahssolutions.my.canva.site/insurancecalculator" class="tool-card" target="_blank" rel="noopener">Is Your Insurance Enough?</a>
-      <a href="https://shahssolutions.my.canva.site/budgettool" class="tool-card" target="_blank" rel="noopener">Budget &amp; Product Suggestor</a>
-      <a href="https://shahssolutions.my.canva.site/editable-premium-due-notice-poster" class="tool-card" target="_blank" rel="noopener">Premium Notice Generator</a>
+      <a href="age-calculator.html" class="tool">Age Calculator</a>
+      <a href="https://shahssolutions.my.canva.site/insurancecalculator" class="tool" target="_blank" rel="noopener">Is Your Insurance Enough?</a>
+      <a href="https://shahssolutions.my.canva.site/budgettool" class="tool" target="_blank" rel="noopener">Budget &amp; Product Suggestor</a>
+      <a href="https://shahssolutions.my.canva.site/editable-premium-due-notice-poster" class="tool" target="_blank" rel="noopener">Premium Notice Generator</a>
+    </div>
+  </div>
+
+  <!-- Plans -->
+  <div class="panel tools">
+    <div class="header">
+      <div class="title"><span class="dot"></span> Plans</div>
+    </div>
+    <div class="tools-grid">
+      <a href="715/index.html" class="tool">Jeevan Anand (715)</a>
     </div>
   </div>
 </div>
@@ -145,6 +102,8 @@
     </div>
   </div>
 </div>
+
+<script src="particles.js"></script>
 
 <script>
   // ===== CONFIG (wired to your deployment) =====

--- a/jarvis.css
+++ b/jarvis.css
@@ -1,0 +1,70 @@
+:root{
+  --bg:#0b0f14;
+  --card:rgba(255,255,255,0.06);
+  --cardBorder:rgba(11,78,162,0.35);
+  --text:#e8f7ff;
+  --muted:#9fb6c3;
+  --accent:#0B4EA2;
+  --ok:#19d27a;
+  --warn:#ffb020;
+  --err:#ff4d4d;
+  --glow:0 0 18px rgba(11,78,162,0.8);
+  --particle:rgba(255,221,0,0.9);
+}
+*{box-sizing:border-box}
+body{margin:0;font-family:system-ui,Segoe UI,Inter,Roboto,Arial;background:radial-gradient(1200px 900px at 10% 10%,#0e1420 0%,#0b0f14 60%,#090c11 100%);color:var(--text)}
+#particles{position:fixed;inset:0;z-index:-1}
+.container{max-width:1100px;margin:28px auto;padding:0 16px}
+.alert{margin-bottom:10px;padding:10px 12px;border-radius:10px;border:1px solid var(--cardBorder);background:rgba(255,255,255,0.06);display:none}
+.alert.err{border-color:#ff4d4d33}
+.panel{background:var(--card);border:1px solid rgba(11,78,162,0.6);backdrop-filter:blur(10px);border-radius:16px;overflow:hidden;box-shadow:0 0 18px rgba(11,78,162,0.5)}
+.header{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--cardBorder)}
+.clickable{cursor:pointer;user-select:none}
+.title{display:flex;align-items:center;gap:10px;font-weight:700;letter-spacing:.2px;text-shadow:var(--glow)}
+.dot{width:8px;height:8px;border-radius:50%;background:var(--accent);box-shadow:var(--glow)}
+actions{display:flex;gap:8px;align-items:center}
+.actions{display:flex;gap:8px;align-items:center}
+.btn{border:1px solid var(--cardBorder);background:rgba(255,255,255,0.05);color:var(--text);padding:8px 12px;border-radius:10px;cursor:pointer}
+.btn.neon{border-color:rgba(11,78,162,0.5);color:#c8f9ff;box-shadow:var(--glow)}
+.btn:disabled{opacity:.6;cursor:not-allowed}
+.badge{min-width:28px;height:28px;padding:0 10px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;border:1px solid rgba(11,78,162,0.35);background:linear-gradient(to bottom right,rgba(11,78,162,0.18),rgba(11,78,162,0.05));font-weight:700;color:#c8f9ff;box-shadow:var(--glow)}
+.content{padding:8px 0}
+.hide{display:none}
+@keyframes glow{from{text-shadow:0 0 8px rgba(11,78,162,0.7)}to{text-shadow:0 0 18px rgba(11,78,162,1)}}
+.jarvis-title,.jarvis-subtitle{text-align:center;color:var(--accent);animation:glow 2s ease-in-out infinite alternate}
+.jarvis-title{margin-top:24px;font-size:2.5em}
+.jarvis-subtitle{font-size:1.5em;margin-bottom:24px}
+.table-wrap{overflow:auto;max-height:58vh}
+table{width:100%;border-collapse:collapse;font-size:14px;table-layout:fixed}
+th,td{padding:12px 14px;border-bottom:1px solid var(--cardBorder);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+th{position:sticky;top:0;background:rgba(8,12,18,0.8);backdrop-filter:blur(6px);text-align:left;color:#cfe6f1}
+tr{transition:background .2s}
+tr:hover{background:rgba(255,255,255,0.05)}
+.muted{color:var(--muted)}
+.pill{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;border:1px solid var(--cardBorder);background:rgba(255,255,255,0.05);font-size:12px}
+.drawer{border-top:1px solid var(--cardBorder);background:rgba(255,255,255,0.04)}
+.drawer-head{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:1px solid var(--cardBorder)}
+.section-title{margin:10px 16px 4px;font-weight:700;font-size:14px;color:#d9f6ff}
+.form{display:grid;gap:10px;padding:14px 16px}
+.row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+label{font-size:12px;color:#b7c7d1}
+input,select,textarea{width:100%;padding:10px 12px;border-radius:10px;border:1px solid var(--cardBorder);background:rgba(255,255,255,0.04);color:var(--text);outline:none}
+.list{padding:6px 16px 16px;display:grid;gap:10px}
+.policy{display:grid;gap:6px;padding:10px;border:1px dashed var(--cardBorder);border-radius:12px}
+.hint{font-size:12px;color:var(--muted)}
+.ok{color:var(--ok)}
+.warn{color:var(--warn)}
+.err{color:var(--err)}
+.tools{margin-top:16px}
+.tools-grid{padding:16px;display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;margin-top:2rem}
+.backdrop{position:fixed;inset:0;background:rgba(0,0,0,0.5);display:none;align-items:center;justify-content:center;z-index:50}
+.backdrop.show{display:flex}
+.modal-panel{width:min(650px,92vw)}
+.result{margin-top:1rem;font-size:1.2rem}
+.contact{text-align:center;margin-top:.5rem}
+.contact a{color:var(--accent);text-decoration:none;margin:0 .5rem}
+.contact a:hover{text-shadow:0 0 5px var(--accent)}
+.tool{display:flex;align-items:center;justify-content:center;padding:1.5rem;text-decoration:none;color:var(--accent);background:rgba(11,78,162,0.1);border:1px solid rgba(11,78,162,0.6);border-radius:12px;transition:.3s;box-shadow:0 0 12px rgba(11,78,162,0.6)}
+.tool:hover{background:rgba(11,78,162,0.2);box-shadow:0 0 20px var(--accent)}
+.card-container{max-width:800px;margin:4rem auto;padding:2rem;background:var(--card);border:1px solid var(--cardBorder);border-radius:20px;backdrop-filter:blur(10px);box-shadow:0 0 20px rgba(11,78,162,0.2)}
+hr{border-color:rgba(11,78,162,0.2);margin:2rem 0}

--- a/particles.js
+++ b/particles.js
@@ -1,0 +1,47 @@
+const canvas = document.getElementById('particles');
+if (canvas) {
+  const ctx = canvas.getContext('2d');
+  let w, h;
+  function resize(){ w = canvas.width = innerWidth; h = canvas.height = innerHeight; }
+  window.addEventListener('resize', resize); resize();
+  const count = 120;
+  const particles = Array.from({length:count}, () => ({
+    x: Math.random()*w,
+    y: Math.random()*h,
+    vx: (Math.random()-0.5)*0.7,
+    vy: (Math.random()-0.5)*0.7
+  }));
+  const color = getComputedStyle(document.documentElement).getPropertyValue('--particle') || 'rgba(255,221,0,0.9)';
+  const maxDist = 120;
+  (function draw(){
+    ctx.clearRect(0,0,w,h);
+    particles.forEach(p=>{
+      p.x+=p.vx; p.y+=p.vy;
+      if(p.x<0||p.x>w) p.vx*=-1;
+      if(p.y<0||p.y>h) p.vy*=-1;
+      ctx.fillStyle = color;
+      ctx.shadowColor = color;
+      ctx.shadowBlur = 12;
+      ctx.beginPath();
+      ctx.arc(p.x,p.y,3,0,Math.PI*2);
+      ctx.fill();
+      ctx.shadowBlur = 0;
+    });
+    for(let i=0;i<count;i++){
+      for(let j=i+1;j<count;j++){
+        const a = particles[i], b = particles[j];
+        const dx = a.x-b.x, dy = a.y-b.y;
+        const dist = Math.hypot(dx,dy);
+        if(dist < maxDist){
+          ctx.strokeStyle = `rgba(255,221,0,${0.3 - dist/maxDist*0.3})`;
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(a.x,a.y);
+          ctx.lineTo(b.x,b.y);
+          ctx.stroke();
+        }
+      }
+    }
+    requestAnimationFrame(draw);
+  })();
+}

--- a/tools.html
+++ b/tools.html
@@ -4,44 +4,28 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LIC Sales Toolkit</title>
-  <style>
-    body{margin:0;background:#000;color:#00eaff;font-family:Arial,sans-serif;overflow:hidden}
-    #particles{position:fixed;inset:0;z-index:-1}
-    .container{max-width:800px;margin:4rem auto;padding:2rem;background:rgba(255,255,255,.05);border:1px solid rgba(0,234,255,.3);border-radius:20px;backdrop-filter:blur(10px);box-shadow:0 0 20px rgba(0,234,255,.2)}
-    h1{text-align:center;margin-top:0}
-    .contact{text-align:center;margin-top:.5rem}
-    .contact a{color:#00eaff;text-decoration:none;margin:0 .5rem}
-    .contact a:hover{text-shadow:0 0 5px #00eaff}
-    .tools{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;margin-top:2rem}
-    .tool{display:flex;align-items:center;justify-content:center;padding:1.5rem;text-decoration:none;color:#00eaff;background:rgba(0,234,255,.1);border:1px solid #00eaff;border-radius:12px;transition:.3s}
-    .tool:hover{background:rgba(0,234,255,.2);box-shadow:0 0 15px #00eaff}
-  </style>
+  <link rel="stylesheet" href="jarvis.css"/>
 </head>
 <body>
 
   <canvas id="particles"></canvas>
   <div class="container">
-    <h1>Urvi Shah — LIC Insurance Advisor</h1>
-    <div class="contact">
-      <a href="tel:9428391746">📞 9428391746</a>
-      <a href="mailto:urvishah2311@gmail.com">✉️ urvishah2311@gmail.com</a>
-    </div>
-    <div class="tools">
-      <a href="age-calculator.html" class="tool">Age Calculator</a>
-      <a href="https://shahssolutions.my.canva.site/insurancecalculator" class="tool" target="_blank" rel="noopener">Is Your Insurance Enough?</a>
-      <a href="https://shahssolutions.my.canva.site/budgettool" class="tool" target="_blank" rel="noopener">Budget &amp; Product Suggestor</a>
-      <a href="https://shahssolutions.my.canva.site/editable-premium-due-notice-poster" class="tool" target="_blank" rel="noopener">Premium Notice Generator</a>
+    <h1 class="jarvis-title">URVI SHAH</h1>
+    <h2 class="jarvis-subtitle">3303</h2>
+    <div class="card-container">
+      <div class="contact">
+        <a href="tel:9428391746">📞 9428391746</a>
+        <a href="mailto:urvishah2311@gmail.com">✉️ urvishah2311@gmail.com</a>
+      </div>
+      <div class="tools-grid">
+        <a href="age-calculator.html" class="tool">Age Calculator</a>
+        <a href="https://shahssolutions.my.canva.site/insurancecalculator" class="tool" target="_blank" rel="noopener">Is Your Insurance Enough?</a>
+        <a href="https://shahssolutions.my.canva.site/budgettool" class="tool" target="_blank" rel="noopener">Budget &amp; Product Suggestor</a>
+        <a href="https://shahssolutions.my.canva.site/editable-premium-due-notice-poster" class="tool" target="_blank" rel="noopener">Premium Notice Generator</a>
+      </div>
     </div>
   </div>
 
- 
-  <script>
-    const canvas=document.getElementById('particles'),ctx=canvas.getContext('2d');
-    function resize(){canvas.width=window.innerWidth;canvas.height=window.innerHeight}
-    window.addEventListener('resize',resize);resize();
-    const particles=[];for(let i=0;i<60;i++){particles.push({x:Math.random()*canvas.width,y:Math.random()*canvas.height,vx:(Math.random()-.5)*.5,vy:(Math.random()-.5)*.5,size:2+Math.random()*2})}
-    function draw(){ctx.clearRect(0,0,canvas.width,canvas.height);particles.forEach(p=>{p.x+=p.vx;p.y+=p.vy;if(p.x<0||p.x>canvas.width)p.vx*=-1;if(p.y<0||p.y>canvas.height)p.vy*=-1;ctx.beginPath();ctx.arc(p.x,p.y,p.size,0,Math.PI*2);ctx.fillStyle='rgba(0,234,255,.5)';ctx.fill()});requestAnimationFrame(draw)}
-    draw();
-  </script>
+  <script src="particles.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Intensify blue holographic borders across panels and cards for a more Jarvis-like feel
- Boost background particles into bright yellow nodes that link together with neon lines
- Align home page tool and plan cards with shared styling so every page matches the Jarvis theme

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a024eed2ec8332a8201fbd070fcade